### PR TITLE
Fix crash due to lack of focusMode being available.

### DIFF
--- a/src/components/StreamBarcodeReader.vue
+++ b/src/components/StreamBarcodeReader.vue
@@ -218,7 +218,7 @@ export default {
         // Find ideal device (hopefully includes torch and continuous focus)
         let idealIndex = deviceOptions.length - 1
         for (let index = 0; index < deviceOptions.length; index++) {
-          if (deviceOptions[index].torch && deviceOptions[index].focusMode.includes('continuous')) {
+          if (deviceOptions[index].torch && deviceOptions[index].focusMode?.includes('continuous')) {
             idealIndex = index
             break
           } else if (deviceOptions[index].torch) {


### PR DESCRIPTION
`focusMode` is no longer available as of iOS 17.4.1. (I cannot confirm when this change took place.)

Currently, the lack of focusMode being available causes the error:
```
[Error] Unhandled Promise Rejection: TypeError: undefined is not an object (evaluating 'e[o].focusMode.includes')
```

This resolves that by making `focusMode` optional.